### PR TITLE
Support for multiple blame ranges

### DIFF
--- a/gix-blame/Cargo.toml
+++ b/gix-blame/Cargo.toml
@@ -10,9 +10,6 @@ authors = ["Christoph Rüßler <christoph.ruessler@mailbox.org>", "Sebastian Thi
 edition = "2021"
 rust-version = "1.70"
 
-[lib]
-doctest = false
-
 [dependencies]
 gix-commitgraph = { version = "^0.28.0", path = "../gix-commitgraph" }
 gix-revwalk = { version = "^0.20.1", path = "../gix-revwalk" }

--- a/gix-blame/src/lib.rs
+++ b/gix-blame/src/lib.rs
@@ -17,7 +17,7 @@
 mod error;
 pub use error::Error;
 mod types;
-pub use types::{BlameEntry, Options, Outcome, Statistics};
+pub use types::{BlameEntry, BlameRanges, Options, Outcome, Statistics};
 
 mod file;
 pub use file::function::file;

--- a/gix-blame/src/types.rs
+++ b/gix-blame/src/types.rs
@@ -8,16 +8,142 @@ use gix_object::bstr::BString;
 use smallvec::SmallVec;
 
 use crate::file::function::tokens_for_diffing;
+use crate::Error;
+
+/// A type to represent one or more line ranges to blame in a file.
+///
+/// This type handles the conversion between git's 1-based inclusive ranges and the internal
+/// 0-based exclusive ranges used by the blame algorithm.
+///
+/// # Examples
+///
+/// ```rust
+/// use gix_blame::BlameRanges;
+///
+/// // Blame lines 20 through 40 (inclusive)
+/// let range = BlameRanges::from_range(20..41);
+///
+/// // Blame multiple ranges
+/// let mut ranges = BlameRanges::new();
+/// ranges.add_range(1..5);   // Lines 1-4
+/// ranges.add_range(10..15); // Lines 10-14
+/// ```
+///
+/// # Line Number Representation
+///
+/// This type uses 1-based inclusive ranges to mirror `git`'s behaviour:
+/// - A range of `20..41` represents 21 lines, spanning from line 20 up to and including line 40
+/// - This will be converted to `19..40` internally as the algorithm uses 0-based ranges that are exclusive at the end
+///
+/// # Empty Ranges
+///
+/// An empty `BlameRanges` (created via `BlameRanges::new()` or `BlameRanges::default()`) means
+/// to blame the entire file, similar to running `git blame` without line number arguments.
+#[derive(Debug, Clone, Default)]
+pub struct BlameRanges {
+    /// The ranges to blame, stored as 1-based inclusive ranges
+    /// An empty Vec means blame the entire file
+    ranges: Vec<Range<u32>>,
+}
+
+impl BlameRanges {
+    /// Create a new empty BlameRanges instance.
+    ///
+    /// An empty instance means to blame the entire file.
+    pub fn new() -> Self {
+        Self { ranges: Vec::new() }
+    }
+
+    /// Add a single range to blame.
+    ///
+    /// The range should be 1-based inclusive.
+    /// If the new range overlaps with or is adjacent to an existing range,
+    /// they will be merged into a single range.
+    pub fn add_range(&mut self, new_range: Range<u32>) {
+        self.merge_range(new_range);
+    }
+
+    /// Create from a single range.
+    ///
+    /// The range should be 1-based inclusive, similar to git's line number format.
+    pub fn from_range(range: Range<u32>) -> Self {
+        Self { ranges: vec![range] }
+    }
+
+    /// Create from multiple ranges.
+    ///
+    /// All ranges should be 1-based inclusive.
+    /// Overlapping or adjacent ranges will be merged.
+    pub fn from_ranges(ranges: Vec<Range<u32>>) -> Self {
+        let mut result = Self::new();
+        for range in ranges {
+            result.merge_range(range);
+        }
+        result
+    }
+
+    /// Attempts to merge the new range with any existing ranges.
+    /// If no merge is possible, adds it as a new range.
+    fn merge_range(&mut self, new_range: Range<u32>) {
+        // First check if this range can be merged with any existing range
+        for range in &mut self.ranges {
+            // Check if ranges overlap or are adjacent
+            if new_range.start <= range.end && range.start <= new_range.end {
+                // Merge the ranges by taking the minimum start and maximum end
+                range.start = range.start.min(new_range.start);
+                range.end = range.end.max(new_range.end);
+                return;
+            }
+        }
+        // If no overlap found, add as new range
+        self.ranges.push(new_range);
+    }
+
+    /// Convert the 1-based inclusive ranges to 0-based exclusive ranges.
+    ///
+    /// This is used internally by the blame algorithm to convert from git's line number format
+    /// to the internal format used for processing.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::InvalidLineRange` if:
+    /// - Any range starts at 0 (must be 1-based)
+    /// - Any range extends beyond the file's length
+    /// - Any range has the same start and end
+    pub fn to_zero_based_exclusive(&self, max_lines: u32) -> Result<Vec<Range<u32>>, Error> {
+        if self.ranges.is_empty() {
+            let range = 0..max_lines;
+            return Ok(vec![range]);
+        }
+
+        let mut result = Vec::with_capacity(self.ranges.len());
+        for range in &self.ranges {
+            if range.start == 0 {
+                return Err(Error::InvalidLineRange);
+            }
+            let start = range.start - 1;
+            let end = range.end;
+            if start >= max_lines || end > max_lines || start == end {
+                return Err(Error::InvalidLineRange);
+            }
+            result.push(start..end);
+        }
+        Ok(result)
+    }
+
+    /// Returns true if no specific ranges are set (meaning blame entire file)
+    pub fn is_empty(&self) -> bool {
+        self.ranges.is_empty()
+    }
+}
 
 /// Options to be passed to [`file()`](crate::file()).
 #[derive(Default, Debug, Clone)]
 pub struct Options {
     /// The algorithm to use for diffing.
     pub diff_algorithm: gix_diff::blob::Algorithm,
-    /// A 1-based inclusive range, in order to mirror `git`’s behaviour. `Some(20..40)` represents
-    /// 21 lines, spanning from line 20 up to and including line 40. This will be converted to
-    /// `19..40` internally as the algorithm uses 0-based ranges that are exclusive at the end.
-    pub range: Option<std::ops::Range<u32>>,
+    /// The ranges to blame in the file.
+    pub range: BlameRanges,
     /// Don't consider commits before the given date.
     pub since: Option<gix_date::Time>,
 }

--- a/gix-blame/tests/fixtures/make_blame_repo.sh
+++ b/gix-blame/tests/fixtures/make_blame_repo.sh
@@ -227,6 +227,7 @@ git merge branch-that-has-earlier-commit || true
 
 git blame --porcelain simple.txt > .git/simple.baseline
 git blame --porcelain -L 1,2 simple.txt > .git/simple-lines-1-2.baseline
+git blame --porcelain -L 1,2 -L 4 simple.txt > .git/simple-lines-multiple-1-2-and-4.baseline
 git blame --porcelain --since 2025-01-31 simple.txt > .git/simple-since.baseline
 git blame --porcelain multiline-hunks.txt > .git/multiline-hunks.baseline
 git blame --porcelain deleted-lines.txt > .git/deleted-lines.baseline

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -1560,7 +1560,7 @@ pub fn main() -> Result<()> {
         Subcommands::Blame {
             statistics,
             file,
-            range,
+            ranges,
             since,
         } => prepare_and_run(
             "blame",
@@ -1578,7 +1578,7 @@ pub fn main() -> Result<()> {
                     &file,
                     gix::blame::Options {
                         diff_algorithm,
-                        range: range.map(BlameRanges::from_range).unwrap_or_default(),
+                        range: gix::blame::BlameRanges::from_ranges(ranges),
                         since,
                     },
                     out,

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -11,7 +11,7 @@ use anyhow::{anyhow, Context, Result};
 use clap::{CommandFactory, Parser};
 use gitoxide_core as core;
 use gitoxide_core::{pack::verify, repository::PathsOrPatterns};
-use gix::bstr::{io::BufReadExt, BString};
+use gix::{bstr::{io::BufReadExt, BString}};
 
 use crate::{
     plumbing::{
@@ -1578,7 +1578,7 @@ pub fn main() -> Result<()> {
                     &file,
                     gix::blame::Options {
                         diff_algorithm,
-                        range,
+                        range: range.map(BlameRanges::from_range).unwrap_or_default(),
                         since,
                     },
                     out,

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -11,7 +11,7 @@ use anyhow::{anyhow, Context, Result};
 use clap::{CommandFactory, Parser};
 use gitoxide_core as core;
 use gitoxide_core::{pack::verify, repository::PathsOrPatterns};
-use gix::{bstr::{io::BufReadExt, BString}};
+use gix::bstr::{io::BufReadExt, BString};
 
 use crate::{
     plumbing::{

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -169,7 +169,7 @@ pub enum Subcommands {
         file: std::ffi::OsString,
         /// Only blame lines in the given 1-based inclusive range '<start>,<end>', e.g. '20,40'.
         #[clap(short='L', value_parser=AsRange, action=clap::ArgAction::Append)]
-        ranges: Vec<std::ops::Range<u32>>,
+        ranges: Vec<std::ops::RangeInclusive<u32>>,
         /// Don't consider commits before the given date.
         #[clap(long,  value_parser=AsTime, value_name = "DATE")]
         since: Option<gix::date::Time>,

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -168,8 +168,8 @@ pub enum Subcommands {
         /// The file to create the blame information for.
         file: std::ffi::OsString,
         /// Only blame lines in the given 1-based inclusive range '<start>,<end>', e.g. '20,40'.
-        #[clap(short='L', value_parser=AsRange)]
-        range: Option<std::ops::Range<u32>>,
+        #[clap(short='L', value_parser=AsRange, action=clap::ArgAction::Append)]
+        ranges: Vec<std::ops::Range<u32>>,
         /// Don't consider commits before the given date.
         #[clap(long,  value_parser=AsTime, value_name = "DATE")]
         since: Option<gix::date::Time>,

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -413,7 +413,7 @@ mod clap {
     pub struct AsRange;
 
     impl TypedValueParser for AsRange {
-        type Value = std::ops::Range<u32>;
+        type Value = std::ops::RangeInclusive<u32>;
 
         fn parse_ref(&self, cmd: &Command, arg: Option<&Arg>, value: &OsStr) -> Result<Self::Value, Error> {
             StringValueParser::new()
@@ -424,7 +424,7 @@ mod clap {
                         let end = u32::from_str(end)?;
 
                         if start <= end {
-                            return Ok(start..end);
+                            return Ok(start..=end);
                         }
                     }
 
@@ -474,11 +474,11 @@ mod value_parser_tests {
         #[derive(Debug, clap::Parser)]
         pub struct Cmd {
             #[clap(long, short='l', value_parser = AsRange)]
-            pub arg: Option<std::ops::Range<u32>>,
+            pub arg: Option<std::ops::RangeInclusive<u32>>,
         }
 
         let c = Cmd::parse_from(["cmd", "-l=1,10"]);
-        assert_eq!(c.arg, Some(1..10));
+        assert_eq!(c.arg, Some(1..=10));
     }
 
     #[test]


### PR DESCRIPTION
This PR adds support for multiple ranges to blame instead of a single-range. This is compatible with `git`'s behavior. Using git it's possible to blame multiple ranges as follows: 
```aiignore
git blame example.rs -L 1,2 -L 2,3 
```
This results in a blame of lines 1-3 in `example.rs`. After this update we are able to run the same command using `gix`!

Initially I tried implementing this without the refactoring to a `BlameRanges` type. However, it became messy quickly because the ranges had the type `Option<Vec<std::ops::Range<u32>>>` type.  With `BlameRanges` the complexity is quite comprehensible I feel. 

A possible improvement could be to add an enum that signals whether  the ranges are `zero_based` or `one_based`.